### PR TITLE
fix(mtproto): preserve bot usernames in user conversion

### DIFF
--- a/mtproto/immutable_user_helper.go
+++ b/mtproto/immutable_user_helper.go
@@ -340,6 +340,14 @@ func (m *ImmutableUser) ToUnsafeUser(selfUser *ImmutableUser) *User {
 		BotActiveUsers:               m.BotActiveUsers(),
 	}).To_User()
 
+	if len(m.Usernames()) > 1 {
+		user.Username = nil
+		user.Usernames = m.Usernames()
+	} else {
+		user.Username = MakeFlagsString(m.Username())
+		user.Usernames = nil
+	}
+
 	if m.IsBot() {
 		user.Photo = m.ProfilePhoto()
 		user.Status = nil
@@ -392,14 +400,6 @@ func (m *ImmutableUser) ToUnsafeUser(selfUser *ImmutableUser) *User {
 
 	//// TODO: check stories_unavailable
 	// user.StoriesUnavailable = false
-
-	if len(m.Usernames()) > 1 {
-		user.Username = nil
-		user.Usernames = m.Usernames()
-	} else {
-		user.Username = MakeFlagsString(m.Username())
-		user.Usernames = nil
-	}
 
 	return user
 }
@@ -583,6 +583,14 @@ func (m *ImmutableUser) ToUser(selfUserId int64) *User {
 		BotActiveUsers:               m.BotActiveUsers(),
 	}).To_User()
 
+	if len(m.Usernames()) > 1 {
+		user.Username = nil
+		user.Usernames = m.Usernames()
+	} else {
+		user.Username = MakeFlagsString(m.Username())
+		user.Usernames = nil
+	}
+
 	if m.IsBot() {
 		user.Photo = m.ProfilePhoto()
 		user.Status = nil
@@ -620,14 +628,6 @@ func (m *ImmutableUser) ToUser(selfUserId int64) *User {
 
 	// TODO: check stories_unavailable
 	// user.StoriesUnavailable = false
-
-	if len(m.Usernames()) > 1 {
-		user.Username = nil
-		user.Usernames = m.Usernames()
-	} else {
-		user.Username = MakeFlagsString(m.Username())
-		user.Usernames = nil
-	}
 
 	return user
 }


### PR DESCRIPTION
## Summary

Fix bot user conversion so bot usernames are preserved when converting `ImmutableUser` to user views.

## Problem

`ImmutableUser.ToUnsafeUser()` and `ImmutableUser.ToUser()` initialize `Username` and `Usernames` as empty, then return early for bot users before copying username fields from `ImmutableUser`.

As a result, callers that fetch bot users through these conversion paths receive bot users without username data, even when the underlying immutable user has a username.

One visible case is BotFather callback handling. Selecting a bot from `/mybots` can produce a message like:

```text
Here it is: allenbot @
```

The bot display name is present, but `botUser.Username` is empty, so the mention text becomes only `@`.

## Root Cause

The conversion currently follows this order:

1. Build a `User` with `Username: nil` and `Usernames: nil`
2. If the source user is a bot, return immediately
3. Populate `Username` or `Usernames` for non-bot users

Because bots return at step 2, they never reach the username population logic.

## Change

Move the `Username/Usernames` population before the bot early return in:

- `ImmutableUser.ToUnsafeUser()`
- `ImmutableUser.ToUser()`

This keeps existing bot-specific behavior intact:

- bot users still return before normal user contact/privacy/status logic
- bot photo/status/stories behavior is unchanged
- public username fields are now preserved for bot users

## Verification

Ran:

```sh
go test ./mtproto
```

Result:

```text
ok  	github.com/teamgram/proto/mtproto
```

Also verified locally that `ToUnsafeUser()` returns a bot user with `Username` populated when the source `ImmutableUser` has a username.

## Notes

This change is intentionally small and only reorders existing username population logic. It does not change username formatting, privacy checks, contact handling, or bot-specific return behavior.
